### PR TITLE
Ensure file exists from set of default files.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,17 +49,17 @@ By running this in the root folder you will also get a public folder
 
 Options are placed in a `.fiddly.config.json` and it contains the following options:
 
-| Option      | Default                     | Description                                                                           |
-| ----------- | --------------------------- | ------------------------------------------------------------------------------------- |
-| file        | Readme                      | Your Readme.md name                                                                   |
-| name        | name in package.json        | The project name that is in the title and the header                                  |
-| logo        | ''                          | The project logo that is in the header                                                |
-| description | description in package.json | The project description for metaTags                                                  |
-| noHeader    | false                       | Show no header and just the markdown content                                          |
-| darkTheme   | false                       | Dark theme ofc 🎉                                                                     |
-| favicon     | ''                          | Favicon url or local path                                                             |
-| dist        | public                      | To what folder to render your HTML                                                    |
-| styles      | {}                          | Styles to apply to the page. This will override everything else. Use any css selector |
+| Option      | Default                               | Description                                                                           |
+| ----------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
+| file        | Readme.md, readme.md, or README.md    | Your Readme.md name                                                                   |
+| name        | name in package.json                  | The project name that is in the title and the header                                  |
+| logo        | ''                                    | The project logo that is in the header                                                |
+| description | description in package.json           | The project description for metaTags                                                  |
+| noHeader    | false                                 | Show no header and just the markdown content                                          |
+| darkTheme   | false                                 | Dark theme ofc 🎉                                                                     |
+| favicon     | ''                                    | Favicon url or local path                                                             |
+| dist        | public                                | To what folder to render your HTML                                                    |
+| styles      | {}                                    | Styles to apply to the page. This will override everything else. Use any css selector |
 
 ### Example of styles
 

--- a/src/commands/fiddly.js
+++ b/src/commands/fiddly.js
@@ -31,7 +31,7 @@ const defaultOptions = {
   dist: 'public',
   darkTheme: false,
   noHeader: false,
-  file: 'Readme' || 'readme' || 'README',
+  file: null,
   name: null,
   description: null,
   styles: {},
@@ -77,8 +77,33 @@ module.exports = {
     )
 
     // HTML
-    const file = options.file
-    const markdown = filesystem.read(`${process.cwd()}/${file}.md`)
+    // Set default filenames list to check for
+    const DEFAULT_FILENAMES = ['readme.md', 'Readme.md', 'README.md']
+    let file
+
+    // Check for `options.file`, if null, check if a default file exists, or error
+    if (options.file === null) {
+      file = DEFAULT_FILENAMES.find(filename => {
+        return filesystem.exists(filename) ? filename : null
+      })
+
+      // Throw error if no default file could be found
+      if (file === null) {
+        throw new TypeError(`No default file ("readme.md", "Readme.md", or "README.md") can be found. Please use the "file" option if using a differing filename.`)
+      }
+    } else {
+      // Set file to the given `options.file` value
+      file = options.file
+    }
+
+    // Get markdown contents of given file
+    const markdown = filesystem.read(`${process.cwd()}/${file}`)
+
+    // Throw error if file does not exist and subsequently can't get markdown from the file.
+    if (typeof markdown === 'undefined') {
+      throw new TypeError(`Cannot find file "${file}". Please ensure file exists.`)
+    }
+
     const description = options.description || packageJSON.description
     const name = options.name || packageJSON.name
     const githubCorner = packageJSON.repository


### PR DESCRIPTION
Hi there! 

This pull request ensures that, if `options.file` is not set, a list of default files is checked against the filesystem to find if any default file exists. If either returns null, two errors are set to throw.

The reason behind this change is that I expected `readme.md` to work, and it does on macOS, since macOS is case insensitive. However, when I was building this on a Linux machine, `readme.md` failed since the code expected the default file to be `Readme.md`. This pull request fixes that issue.

I hope this is okay!