### PR TITLE
Allows for specifying fiddly config in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ coverage
 .nyc_output
 yarn-error.lock
 public
+__tests__/testoutput
 package.lock
 .eslintcache

--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ By running this in the root folder you will also get a public folder
 
 ## Options
 
-Options are placed in a `.fiddly.config.json` and it contains the following options:
+Options are placed in a `.fiddly.config.json` or as a "fiddly" key in `package.json` and it contains the following options:
 
 | Option      | Default                     | Description                                                                           |
 | ----------- | --------------------------- | ------------------------------------------------------------------------------------- |
@@ -69,6 +69,23 @@ Options are placed in a `.fiddly.config.json` and it contains the following opti
     "h1": {
       "color": "blue",
       "backgroundColor": "red"
+    }
+  }
+}
+```
+
+Or in `package.json`:
+
+```json
+{
+  "name": "my-package",
+  // ...
+  "fiddly": {
+    "styles": {
+      "h1": {
+        "color": "blue",
+        "backgroundColor": "red"
+      }
     }
   }
 }

--- a/__tests__/cli-integration.test.js
+++ b/__tests__/cli-integration.test.js
@@ -1,11 +1,10 @@
 const { system, filesystem } = require('gluegun')
-const { resolve } = require('path')
 
-const src = resolve(__dirname, '..')
+const src = filesystem.path(__dirname, '..')
 const success = `Generated your static files at public/`
 
 const cli = async cmd =>
-  system.run('node ' + resolve(src, 'bin', 'fiddly') + ` ${cmd}`)
+  system.run('node ' + filesystem.path(src, 'bin', 'fiddly') + ` ${cmd}`)
 
 test('generates html', async () => {
   const output = await cli()
@@ -41,4 +40,21 @@ test('generates dark', async () => {
 
   // cleanup artifact
   filesystem.remove('public')
+})
+
+test('reads config from package.json', async () => {
+  const prevDir = process.cwd()
+
+  process.chdir('./__tests__/testpkg')
+
+  const output = await cli()
+
+  expect(output).toContain(success.replace('public', 'testoutput'))
+  const css = filesystem.read('testoutput/style.css')
+
+  expect(css).toContain(`font-size:18em`)
+
+  // cleanup artifact
+  filesystem.remove('testoutput')
+  process.chdir(prevDir)
 })

--- a/__tests__/testpkg/package.json
+++ b/__tests__/testpkg/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "testpkg",
+  "fiddly": {
+    "dist": "testoutput",
+    "styles": {
+      "h1": {
+        "font-size": "18em"
+      }
+    }
+  }
+}

--- a/__tests__/testpkg/readme.md
+++ b/__tests__/testpkg/readme.md
@@ -1,0 +1,3 @@
+# Just a test
+
+Testing a thing.

--- a/src/commands/fiddly.js
+++ b/src/commands/fiddly.js
@@ -47,13 +47,15 @@ module.exports = {
       filesystem
     } = toolbox
 
+    const packageJSON =
+      filesystem.read(`${process.cwd()}/package.json`, 'json') || {}
+
     const options = {
       ...defaultOptions,
+      ...(packageJSON.fiddly || {}),
       ...(filesystem.read(`${process.cwd()}/.fiddly.config.json`, 'json') || {})
     }
     const dist = options.dist
-    const packageJSON =
-      filesystem.read(`${process.cwd()}/package.json`, 'json') || {}
 
     // CSS
     const css = filesystem


### PR DESCRIPTION
First off, I'm very happy to see you using my Gluegun package to power Fiddly. :)

Secondly, I made an improvement here -- you can now specify a "fiddly" property in your `package.json` instead of using a `.fiddly.config.json` (you can still do the separate file if you wish).

```json5
{
  "name": "mypackage",
  // ...
  "fiddly": {
    // fiddly config here
  }
}
```
