### PR TITLE
Support deploying with ZEIT Now

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,6 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "package.json", "use": "@now/static-build", "config": { "distDir": "public" } }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "./bin/fiddly.js",
     "prepublish": "npm run test",
     "contributors:add": "all-contributors add",
-    "contributors:generate": "all-contributors generate"
+    "contributors:generate": "all-contributors generate",
+    "now-build": "npm run build"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
Hello again!
This pull request adds support for building and deploying with ZEIT Now and the [@now/static-build Builder](https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build/).

This repository will deploy automatically if you install Now for GitHub 🎉: https://zeit.co/docs/v2/integrations/now-for-github/