### PR TITLE
Add default alias with Now deployment

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "alias": "fiddly",
   "builds": [
     { "src": "package.json", "use": "@now/static-build", "config": { "distDir": "public" } }
   ]

--- a/now.json
+++ b/now.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "alias": "fiddly",
+  "public": true,
   "builds": [
     { "src": "package.json", "use": "@now/static-build", "config": { "distDir": "public" } }
   ]


### PR DESCRIPTION
This pull request adds a default alias for Now deployments, it will deploy with Now for GitHub and then alias when pushed to master to `fiddly.now.sh`.